### PR TITLE
Update akka-http to 10.2.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val commonsCodec = "commons-codec" % "commons-codec" % "1.15"
 val bouncyCastle = "org.bouncycastle" % "bcpkix-jdk15on" % "1.68"
 
 // the client API request/response handing uses Akka Http
-val akkaHttp = "com.typesafe.akka" %% "akka-http" % "10.1.14"
+val akkaHttp = "com.typesafe.akka" %% "akka-http" % "10.2.4"
 val akkaStream = "com.typesafe.akka" %% "akka-stream" % akkaVersion
 val akka = "com.typesafe.akka" %% "akka-actor" % akkaVersion
 

--- a/client/src/main/scala/skuber/api/client/exec/PodExecImpl.scala
+++ b/client/src/main/scala/skuber/api/client/exec/PodExecImpl.scala
@@ -51,7 +51,11 @@ object PodExecImpl {
     // Determine scheme and connection context based on SSL context
     val (scheme, connectionContext) = requestContext.sslContext match {
       case Some(ssl) =>
-        ("wss",ConnectionContext.https(ssl, enabledProtocols = Some(scala.collection.immutable.Seq("TLSv1.2", "TLSv1"))))
+        ("wss", ConnectionContext.httpsClient { (host, port) =>
+          val engine = ssl.createSSLEngine(host, port)
+          engine.setEnabledProtocols(Array("TLSv1.2", "TLSv1"))
+          engine
+        })
       case None =>
         ("ws", Http().defaultClientHttpsContext)
     }


### PR DESCRIPTION
Hi,

I have manually updated akka-http to 10.2.4. Deprecation warning and tests are fixed according to migration guide.

BR