### PR TITLE
Issue 204 - Bound tokens for incluster configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val scala12Version = "2.12.13"
 val scala13Version = "2.13.6"
 val scala3Version = "3.1.3"
 
-val currentScalaVersion = scala13Version
+val currentScalaVersion = scala12Version
 
 ThisBuild / scalaVersion := currentScalaVersion
 

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val scala12Version = "2.12.13"
 val scala13Version = "2.13.6"
 val scala3Version = "3.1.3"
 
-val currentScalaVersion = scala12Version
+val currentScalaVersion = scala13Version
 
 ThisBuild / scalaVersion := currentScalaVersion
 

--- a/client/src/main/resources/reference.conf
+++ b/client/src/main/resources/reference.conf
@@ -32,4 +32,8 @@ skuber {
     # reclaim the unused resources.
     pool-idle-timeout = 30s
   }
+
+  in-cluster {
+    refresh-token-interval = 5m
+  }
 }

--- a/client/src/main/scala/skuber/api/Configuration.scala
+++ b/client/src/main/scala/skuber/api/Configuration.scala
@@ -10,6 +10,8 @@ import java.util.{Base64, Date}
 import org.yaml.snakeyaml.Yaml
 import skuber.Namespace
 import skuber.api.client._
+import skuber.api.client.token.{FileTokenAuthRefreshable, FileTokenConfiguration}
+
 import scala.io.Source
 
 /**
@@ -258,7 +260,9 @@ object Configuration {
       namespace <- maybeNamespace
       hostPort  = s"https://$host${if (port.length > 0) ":" + port else ""}"
       cluster   = Cluster(server = hostPort, certificateAuthority = ca)
-      ctx       = Context(cluster, TokenAuth(token), Namespace.forName(namespace))
+      ctx       = Context(cluster = cluster,
+        authInfo = FileTokenAuthRefreshable(FileTokenConfiguration(cachedAccessToken= Some(token), tokenPath = Some(tokenPath))),
+        namespace = Namespace.forName(namespace))
     } yield Configuration(clusters = Map("default" -> cluster),
       contexts = Map("default" -> ctx),
       currentContext = ctx)
@@ -297,5 +301,4 @@ object Configuration {
         }
     }
   }
-
 }

--- a/client/src/main/scala/skuber/api/client/exec/PodExecImpl.scala
+++ b/client/src/main/scala/skuber/api/client/exec/PodExecImpl.scala
@@ -127,7 +127,7 @@ object PodExecImpl {
       requestContext.log.info(s"Connected to container ${containerPrintName} of pod ${podName}")
       close.future.foreach { _ =>
         requestContext.log.info(s"Close the connection of container ${containerPrintName} of pod ${podName}")
-        promise.success(None)
+        promise.trySuccess(None)
       }
     }
     Future.sequence(Seq(connected, close.future, promise.future)).map { _ => () }

--- a/client/src/main/scala/skuber/api/client/token/FileTokenAuthRefreshable.scala
+++ b/client/src/main/scala/skuber/api/client/token/FileTokenAuthRefreshable.scala
@@ -1,0 +1,63 @@
+package skuber.api.client.token
+
+import org.joda.time.DateTime
+import skuber.K8SException
+import skuber.api.client.{AuthProviderRefreshableAuth, Status}
+
+import scala.concurrent.duration.{Duration, DurationInt}
+import scala.util.{Failure, Success}
+
+final case class FileTokenAuthRefreshable(config: FileTokenConfiguration) extends TokenAuthRefreshable with FileReaderComponent {}
+
+final case class FileTokenConfiguration(
+    cachedAccessToken: Option[RefreshableToken],
+    tokenPath: Option[String],
+    refreshInterval: Duration = 5.minutes,
+)
+
+trait TokenAuthRefreshable extends AuthProviderRefreshableAuth { self: ContentReaderComponent =>
+  val config: FileTokenConfiguration
+
+  private val refreshInterval: Duration = config.refreshInterval
+  @volatile private var cachedToken: Option[RefreshableToken] = config.cachedAccessToken
+
+  private val tokenPath: String = {
+    config.tokenPath.getOrElse {
+      throw new K8SException(
+        Status(reason = Some("token path not found, please provide the token path for refreshing the token"))
+      )
+    }
+  }
+
+  override def name: String = "file-token"
+  override def toString: String = """FileTokenAuthRefreshable(accessToken=<redacted>)""".stripMargin
+
+  override def refreshToken: RefreshableToken = {
+    val refreshedToken = RefreshableToken(generateToken, DateTime.now.plus(refreshInterval.toMillis))
+    cachedToken = Some(refreshedToken)
+    refreshedToken
+  }
+
+  override def generateToken: String = {
+    val maybeToken = contentReader.read(tokenPath)
+    maybeToken match {
+      case Success(token) => token
+      case Failure(e) => throw new K8SException(Status(reason = Option(e.getMessage)))
+    }
+  }
+
+  override def isTokenExpired(refreshableToken: RefreshableToken): Boolean =
+    refreshableToken.expiry.isBefore(System.currentTimeMillis)
+
+  override def accessToken: String = this.synchronized {
+    cachedToken match {
+      case Some(token) if isTokenExpired(token) =>
+        refreshToken.accessToken
+      case None =>
+        refreshToken.accessToken
+      case Some(token) =>
+        token.accessToken
+    }
+  }
+}
+

--- a/client/src/main/scala/skuber/api/client/token/FileTokenAuthRefreshable.scala
+++ b/client/src/main/scala/skuber/api/client/token/FileTokenAuthRefreshable.scala
@@ -11,7 +11,7 @@ final case class FileTokenAuthRefreshable(config: FileTokenConfiguration) extend
 
 final case class FileTokenConfiguration(
     cachedAccessToken: Option[String],
-    tokenPath: Option[String],
+    tokenPath: String,
     refreshInterval: Duration = 5.minutes,
 )
 
@@ -21,13 +21,7 @@ trait TokenAuthRefreshable extends AuthProviderRefreshableAuth { self: ContentRe
   private val refreshInterval: Duration = config.refreshInterval
   @volatile private var cachedToken: Option[RefreshableToken] = config.cachedAccessToken.map(buildRefreshableToken)
 
-  private val tokenPath: String = {
-    config.tokenPath.getOrElse {
-      throw new K8SException(
-        Status(reason = Some("token path not found, please provide the token path for refreshing the token"))
-      )
-    }
-  }
+  private val tokenPath: String = config.tokenPath
 
   override def name: String = "file-token"
   override def toString: String = """FileTokenAuthRefreshable(accessToken=<redacted>)""".stripMargin

--- a/client/src/main/scala/skuber/api/client/token/package.scala
+++ b/client/src/main/scala/skuber/api/client/token/package.scala
@@ -1,0 +1,26 @@
+package skuber.api.client
+
+import scala.io.Source
+import scala.util.Try
+
+package object token {
+  trait ContentReaderComponent {
+    val contentReader: ContentReader
+
+    trait ContentReader {
+      def read(filePath: String): Try[String]
+    }
+  }
+
+  trait FileReaderComponent extends ContentReaderComponent {
+    val contentReader: ContentReader = new FileContentReader
+
+    class FileContentReader extends ContentReader {
+      def read(filePath: String): Try[String] = for {
+        source <- Try(Source.fromFile(filePath, "utf-8"))
+        content  <- Try(source.getLines().mkString("\n"))
+        _      <- Try(source.close())
+      } yield content
+    }
+  }
+}

--- a/client/src/main/scala/skuber/config/SkuberConfig.scala
+++ b/client/src/main/scala/skuber/config/SkuberConfig.scala
@@ -1,0 +1,32 @@
+package skuber.config
+
+import com.typesafe.config.{Config, ConfigFactory}
+import skuber.config.SkuberConfig.skuberKeyPath
+
+import scala.concurrent.duration.Duration
+
+case class SkuberConfig(appConfig: Config) {
+  def getSkuberConfig[T](key: String, fromConfig: String => Option[T], default: T): T = {
+    val skuberConfigKey = s"$skuberKeyPath.$key"
+    if (appConfig.getIsNull(skuberConfigKey)) {
+      default
+    } else {
+      fromConfig(skuberConfigKey) match {
+        case None => default
+        case Some(t) => t
+      }
+    }
+  }
+
+  def getDuration(configKey: String, default: Duration = Duration.Inf): Duration = getSkuberConfig(configKey, durationFromConfig, default)
+  def durationFromConfig(configKey: String): Option[Duration] = Some(Duration.fromNanos(appConfig.getDuration(configKey).toNanos))
+}
+
+object SkuberConfig {
+  final val skuberKeyPath = "skuber"
+
+  def load(appConfig: Config = ConfigFactory.load()): SkuberConfig = {
+    appConfig.checkValid(ConfigFactory.defaultReference(), skuberKeyPath)
+    SkuberConfig(appConfig)
+  }
+}

--- a/client/src/test/scala/skuber/api/client/token/FileTokenAuthRefreshableSpec.scala
+++ b/client/src/test/scala/skuber/api/client/token/FileTokenAuthRefreshableSpec.scala
@@ -22,13 +22,13 @@ class FileTokenAuthRefreshableSpec extends Specification {
   "FileTokenAuthRefreshable" should {
     "Retrieve the token if none provided" in {
       val initialToken : Option[String] = None
-      val fileTokenRefreshable = MockFileTokenAuthRefreshable(FileTokenConfiguration(cachedAccessToken = initialToken, tokenPath = Some("/tmp/token"), refreshInterval = 100.milliseconds))
+      val fileTokenRefreshable = MockFileTokenAuthRefreshable(FileTokenConfiguration(cachedAccessToken = initialToken, tokenPath = "/tmp/token", refreshInterval = 100.milliseconds))
       fileTokenRefreshable.accessToken.nonEmpty must beTrue
     }
 
     "Refresh the token after the refresh interval" in {
       val initialToken = "cachedToken"
-      val fileTokenRefreshable = MockFileTokenAuthRefreshable(FileTokenConfiguration(Some(initialToken), Some("/tmp/token"), 100.milliseconds))
+      val fileTokenRefreshable = MockFileTokenAuthRefreshable(FileTokenConfiguration(Some(initialToken), "/tmp/token", 100.milliseconds))
       fileTokenRefreshable.accessToken shouldEqual initialToken
 
       Thread.sleep(150)

--- a/client/src/test/scala/skuber/api/client/token/FileTokenAuthRefreshableSpec.scala
+++ b/client/src/test/scala/skuber/api/client/token/FileTokenAuthRefreshableSpec.scala
@@ -21,19 +21,19 @@ class FileTokenAuthRefreshableSpec extends Specification {
 
   "FileTokenAuthRefreshable" should {
     "Retrieve the token if none provided" in {
-      val initialToken : Option[RefreshableToken] = None
+      val initialToken : Option[String] = None
       val fileTokenRefreshable = MockFileTokenAuthRefreshable(FileTokenConfiguration(cachedAccessToken = initialToken, tokenPath = Some("/tmp/token"), refreshInterval = 100.milliseconds))
       fileTokenRefreshable.accessToken.nonEmpty must beTrue
     }
 
     "Refresh the token after the refresh interval" in {
-      val initialToken = RefreshableToken("cachedToken", DateTime.now.plus(100.milliseconds.toMillis))
+      val initialToken = "cachedToken"
       val fileTokenRefreshable = MockFileTokenAuthRefreshable(FileTokenConfiguration(Some(initialToken), Some("/tmp/token"), 100.milliseconds))
-      fileTokenRefreshable.accessToken shouldEqual initialToken.accessToken
+      fileTokenRefreshable.accessToken shouldEqual initialToken
 
       Thread.sleep(150)
       val refreshed = fileTokenRefreshable.accessToken
-      refreshed shouldNotEqual initialToken.accessToken
+      refreshed shouldNotEqual initialToken
 
       Thread.sleep(150)
       fileTokenRefreshable.accessToken shouldNotEqual refreshed

--- a/client/src/test/scala/skuber/api/client/token/FileTokenAuthRefreshableSpec.scala
+++ b/client/src/test/scala/skuber/api/client/token/FileTokenAuthRefreshableSpec.scala
@@ -1,0 +1,42 @@
+package skuber.api.client.token
+
+import org.joda.time.DateTime
+import org.specs2.mutable.Specification
+
+import scala.concurrent.duration.DurationInt
+import scala.util.Try
+
+class FileTokenAuthRefreshableSpec extends Specification {
+  "This is a specification for the 'FileTokenAuthRefreshable' class".txt
+
+  trait MockFileReaderComponent extends ContentReaderComponent {
+    val contentReader: ContentReader = new MockFileReaderComponent
+
+    class MockFileReaderComponent extends ContentReader {
+      def read(filePath: String): Try[String] = Try(DateTime.now.toString())
+    }
+  }
+
+  final case class MockFileTokenAuthRefreshable(config: FileTokenConfiguration) extends TokenAuthRefreshable with MockFileReaderComponent {}
+
+  "FileTokenAuthRefreshable" should {
+    "Retrieve the token if none provided" in {
+      val initialToken : Option[RefreshableToken] = None
+      val fileTokenRefreshable = MockFileTokenAuthRefreshable(FileTokenConfiguration(cachedAccessToken = initialToken, tokenPath = Some("/tmp/token"), refreshInterval = 100.milliseconds))
+      fileTokenRefreshable.accessToken.nonEmpty must beTrue
+    }
+
+    "Refresh the token after the refresh interval" in {
+      val initialToken = RefreshableToken("cachedToken", DateTime.now.plus(100.milliseconds.toMillis))
+      val fileTokenRefreshable = MockFileTokenAuthRefreshable(FileTokenConfiguration(Some(initialToken), Some("/tmp/token"), 100.milliseconds))
+      fileTokenRefreshable.accessToken shouldEqual initialToken.accessToken
+
+      Thread.sleep(150)
+      val refreshed = fileTokenRefreshable.accessToken
+      refreshed shouldNotEqual initialToken.accessToken
+
+      Thread.sleep(150)
+      fileTokenRefreshable.accessToken shouldNotEqual refreshed
+    }
+  }
+}

--- a/client/src/test/scala/skuber/config/SkuberConfigSpec.scala
+++ b/client/src/test/scala/skuber/config/SkuberConfigSpec.scala
@@ -1,0 +1,43 @@
+package skuber.config
+
+import com.typesafe.config.ConfigFactory
+import org.specs2.mutable.Specification
+
+import scala.concurrent.duration.{Duration, DurationInt}
+
+class SkuberConfigSpec extends Specification {
+  "This is a specification for the 'SkuberConfigSpec' class".txt
+
+  "SkuberConfig" should {
+    "in-cluster" should {
+      "refresh token interval defaults to 5 min if no configuration provided" in {
+        val refreshTokenInterval = SkuberConfig.load().getDuration("in-cluster.refresh-token-interval")
+        refreshTokenInterval shouldEqual 5.minutes
+      }
+
+      "refresh token interval value provided by the configuration" in {
+        val appConfig = ConfigFactory.parseString(
+          """
+            |skuber.in-cluster.refresh-token-interval = 100ms
+        """.stripMargin)
+          .withFallback(ConfigFactory.load())
+
+        val refreshTokenInterval = SkuberConfig.load(appConfig).getDuration("in-cluster.refresh-token-interval")
+        refreshTokenInterval shouldEqual 100.milliseconds
+      }
+    }
+    "watch-continuously" should {
+      "defaults are provided" in {
+        val skuberConfig = SkuberConfig.load()
+        val watchContinuouslyRequestTimeout: Duration = skuberConfig.getDuration("watch-continuously.request-timeout")
+        watchContinuouslyRequestTimeout shouldEqual 30.seconds
+
+        val watchContinuouslyIdleTimeout: Duration = skuberConfig.getDuration("watch-continuously.idle-timeout")
+        watchContinuouslyIdleTimeout shouldEqual 60.seconds
+
+        val watchPoolIdleTimeout: Duration = skuberConfig.getDuration("watch-continuously.pool-idle-timeout")
+        watchPoolIdleTimeout shouldEqual 30.seconds
+      }
+    }
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,21 @@ Initiailly Skuber tries out-of-cluster methods in sequence (stops on first succe
 
 If all above fails Skuber tries [in-cluster configuration method](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod)
 
+### In Cluster configuration
+
+Since kubernetes 1.21 the service account tokens have changed to bound service account tokens (See: [Bound Service Account Token Volume](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume)). The service account token needs to be refreshed and reloaded periodically from disk. 
+Skuber by default reloads the token from disk every 5 minutes.
+
+The refresh token interval can be changed updating the following configuration property:
+
+```config
+skuber {
+  in-config {
+    refresh-token-interval = 5m
+  }
+}
+```
+
 
 
 ### Security


### PR DESCRIPTION
FIX #204 

* New FileTokenAuthRefreshable to refresh the token from the pod every 5 min 
* InCluster configuration changes TokenAuth to use FileTokenAuthRefreshable
* PodExecImpl - Sometimes was throwing a `Promise already completed` Exception. Changes `promise.success` to `promise.trysuccess`