### PR TITLE
Added storageClassName to PersistentVolume Spec

### DIFF
--- a/client/src/main/scala/skuber/PersistentVolume.scala
+++ b/client/src/main/scala/skuber/PersistentVolume.scala
@@ -48,7 +48,8 @@ object PersistentVolume {
                    source: Volume.PersistentSource,
                    accessModes: List[AccessMode.AccessMode] = List(),
                    claimRef: Option[ObjectReference] = None,
-                   persistentVolumeReclaimPolicy: Option[ReclaimPolicy.ReclaimPolicy] = None)
+                   persistentVolumeReclaimPolicy: Option[ReclaimPolicy.ReclaimPolicy] = None,
+                   storageClassName: Option[String] = None)
 
   case class Status(phase: Option[Phase.Phase] = None,
                      accessModes: List[AccessMode.AccessMode] = List())

--- a/client/src/main/scala/skuber/json/package.scala
+++ b/client/src/main/scala/skuber/json/package.scala
@@ -883,7 +883,8 @@ package object format {
     JsPath.format[PersistentSource] and
     (JsPath \ "accessModes").formatMaybeEmptyList[PersistentVolume.AccessMode.AccessMode] and
     (JsPath \ "claimRef").formatNullable[ObjectReference] and
-    (JsPath \ "persistentVolumeReclaimPolicy").formatNullableEnum(PersistentVolume.ReclaimPolicy)) (PersistentVolume.Spec.apply, p => (p.capacity, p.source, p.accessModes, p.claimRef, p.persistentVolumeReclaimPolicy))
+    (JsPath \ "persistentVolumeReclaimPolicy").formatNullableEnum(PersistentVolume.ReclaimPolicy) and
+    (JsPath \ "storageClassName").formatNullable[String]) (PersistentVolume.Spec.apply, p => (p.capacity, p.source, p.accessModes, p.claimRef, p.persistentVolumeReclaimPolicy, p.storageClassName))
 
   implicit val persVolStatusFmt: Format[PersistentVolume.Status] = ((JsPath \ "phase").formatNullableEnum(PersistentVolume.Phase) and
     (JsPath \ "accessModes").formatMaybeEmptyList[PersistentVolume.AccessMode.AccessMode]) (PersistentVolume.Status.apply, p => (p.phase, p.accessModes))


### PR DESCRIPTION
StorageClassName is a valid attribute to the PersistentVolumeSpec:
https://docs.openshift.com/container-platform/3.11/rest_api/core/persistentvolume-core-v1.html

And needed to use the Yandex S3 CSI Driver.