### PR TITLE
Change KubernetesClient.close to close() as it's a side-effecting method

### DIFF
--- a/client/src/it/scala/skuber/CustomResourceSpec.scala
+++ b/client/src/it/scala/skuber/CustomResourceSpec.scala
@@ -66,7 +66,7 @@ class CustomResourceSpec extends K8SFixture with Eventually with Matchers with F
 
     results.onComplete { _ =>
       results2.onComplete { _ =>
-        k8s.close
+        k8s.close()
         system.terminate().recover { case _ => () }.valueT
       }
     }

--- a/client/src/it/scala/skuber/CustomResourceV1Spec.scala
+++ b/client/src/it/scala/skuber/CustomResourceV1Spec.scala
@@ -50,7 +50,7 @@ class CustomResourceV1Spec extends K8SFixture with Eventually with Matchers with
     val results = k8s.delete[CustomResourceDefinition](TestResource.crd.name).withTimeout().recover { case _ => () }
     results.futureValue
 
-    k8s.close
+    k8s.close()
     system.terminate().recover { case _ => () }.valueT
   }
 

--- a/client/src/it/scala/skuber/DeploymentSpec.scala
+++ b/client/src/it/scala/skuber/DeploymentSpec.scala
@@ -52,7 +52,7 @@ class DeploymentSpec extends K8SFixture with Eventually with Matchers with Befor
       List(namespace1, namespace2, namespace3, namespace4, namespace5).foreach { name =>
         deleteNamespace(name, k8s)
       }
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
 

--- a/client/src/it/scala/skuber/DynamicKubernetesClientImplTest.scala
+++ b/client/src/it/scala/skuber/DynamicKubernetesClientImplTest.scala
@@ -31,7 +31,7 @@ class DynamicKubernetesClientImplTest extends K8SFixture with Eventually with Ma
     results.valueT
 
     results.onComplete { _ =>
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
   }

--- a/client/src/it/scala/skuber/ExecSpec.scala
+++ b/client/src/it/scala/skuber/ExecSpec.scala
@@ -35,7 +35,7 @@ class ExecSpec extends K8SFixture with Eventually with Matchers with BeforeAndAf
 
     results.onComplete { _ =>
       deleteNamespace(namespace1, k8s)
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
   }

--- a/client/src/it/scala/skuber/HorizontalPodAutoscalerV2Beta1Spec.scala
+++ b/client/src/it/scala/skuber/HorizontalPodAutoscalerV2Beta1Spec.scala
@@ -44,7 +44,7 @@ class HorizontalPodAutoscalerV2Beta1Spec extends K8SFixture with Eventually with
       _ <- results1
       _ <- results2
     } yield {
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
 

--- a/client/src/it/scala/skuber/HorizontalPodAutoscalerV2Spec.scala
+++ b/client/src/it/scala/skuber/HorizontalPodAutoscalerV2Spec.scala
@@ -47,7 +47,7 @@ class HorizontalPodAutoscalerV2Spec extends K8SFixture with Eventually with Matc
       _ <- results1
       _ <- results2
     } yield {
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
 

--- a/client/src/it/scala/skuber/K8SFixture.scala
+++ b/client/src/it/scala/skuber/K8SFixture.scala
@@ -25,7 +25,7 @@ trait K8SFixture extends FixtureAnyFlatSpec {
     try {
       test(k8s)
     } finally {
-      k8s.close
+      k8s.close()
     }
   }
 

--- a/client/src/it/scala/skuber/NamespaceSpec.scala
+++ b/client/src/it/scala/skuber/NamespaceSpec.scala
@@ -35,7 +35,7 @@ class NamespaceSpec extends K8SFixture with Eventually with Matchers with ScalaF
     results.futureValue
 
     results.onComplete { _ =>
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
   }

--- a/client/src/it/scala/skuber/PatchSpec.scala
+++ b/client/src/it/scala/skuber/PatchSpec.scala
@@ -33,7 +33,7 @@ class PatchSpec extends K8SFixture with Eventually with Matchers with BeforeAndA
 
     results.onComplete { _ =>
       deleteNamespace(namespace5, k8s)
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
   }

--- a/client/src/it/scala/skuber/PodDisruptionBudgetSpec.scala
+++ b/client/src/it/scala/skuber/PodDisruptionBudgetSpec.scala
@@ -48,7 +48,7 @@ class PodDisruptionBudgetSpec extends K8SFixture with Matchers with BeforeAndAft
       _ <- results1
       _ <- results2
     } yield {
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
 

--- a/client/src/it/scala/skuber/PodLogSpec.scala
+++ b/client/src/it/scala/skuber/PodLogSpec.scala
@@ -26,7 +26,7 @@ class PodLogSpec extends K8SFixture with Eventually with Matchers with BeforeAnd
     val result = k8s.delete[Pod](podName).withTimeout().recover{ case _ => () }
     result.futureValue
     result.onComplete { _ =>
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
   }

--- a/client/src/it/scala/skuber/PodSpec.scala
+++ b/client/src/it/scala/skuber/PodSpec.scala
@@ -21,7 +21,7 @@ class PodSpec extends K8SFixture with Eventually with Matchers with BeforeAndAft
     results.futureValue
 
     results.onComplete { _ =>
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
   }

--- a/client/src/it/scala/skuber/ServiceAccountSpec.scala
+++ b/client/src/it/scala/skuber/ServiceAccountSpec.scala
@@ -45,7 +45,7 @@ class ServiceAccountSpec extends K8SFixture with Eventually with BeforeAndAfterA
 
     results.onComplete { _ =>
       results2.onComplete { _ =>
-        k8s.close
+        k8s.close()
         system.terminate().recover { case _ => () }.valueT
       }
     }

--- a/client/src/it/scala/skuber/ServiceSpec.scala
+++ b/client/src/it/scala/skuber/ServiceSpec.scala
@@ -44,7 +44,7 @@ class ServiceSpec extends K8SFixture with Eventually with BeforeAndAfterAll with
 
     results.onComplete { _ =>
       results2.onComplete { _ =>
-        k8s.close
+        k8s.close()
         system.terminate().recover { case _ => () }.valueT
       }
     }

--- a/client/src/it/scala/skuber/WatchContinuouslySpec.scala
+++ b/client/src/it/scala/skuber/WatchContinuouslySpec.scala
@@ -34,7 +34,7 @@ class WatchContinuouslySpec extends K8SFixture with Eventually with Matchers wit
     results.futureValue
 
     results.onComplete { _ =>
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
 

--- a/client/src/it/scala/skuber/format/PodFormatSpec.scala
+++ b/client/src/it/scala/skuber/format/PodFormatSpec.scala
@@ -110,7 +110,7 @@ class PodFormatSpec extends K8SFixture with Eventually with Matchers with Before
     results.futureValue
 
     results.onComplete { _ =>
-      k8s.close
+      k8s.close()
       system.terminate().recover { case _ => () }.valueT
     }
   }

--- a/client/src/main/scala/skuber/api/client/KubernetesClient.scala
+++ b/client/src/main/scala/skuber/api/client/KubernetesClient.scala
@@ -403,7 +403,7 @@ trait KubernetesClient {
   /**
     * Closes the client. Any requests to the client after this is called will be rejected.
     */
-  def close: Unit
+  def close(): Unit
 
   // Some parameters of the client that it may be useful for some applications to read
   val logConfig: LoggingConfig // the logging configuration for client requests

--- a/client/src/main/scala/skuber/api/client/impl/KubernetesClientImpl.scala
+++ b/client/src/main/scala/skuber/api/client/impl/KubernetesClientImpl.scala
@@ -602,7 +602,7 @@ class KubernetesClientImpl private[client] (val requestMaker: (Uri, HttpMethod) 
     PodExecImpl.exec(this, podName, command, maybeContainerName, maybeStdin, maybeStdout, maybeStderr, tty, maybeClose, namespace)
   }
 
-  override def close: Unit =
+  override def close(): Unit =
   {
     isClosed = true
     closeHook foreach {

--- a/examples/src/main/scala/skuber/examples/argo/EventBusExample.scala
+++ b/examples/src/main/scala/skuber/examples/argo/EventBusExample.scala
@@ -31,7 +31,7 @@ object EventBusExample extends App {
   }(dispatcher)
   Await.result(ls, 30.seconds)
 
-  k8s.close
+  k8s.close()
 
   Await.result(system.terminate(), 10.seconds)
 

--- a/examples/src/main/scala/skuber/examples/auth/AwsAuthExample.scala
+++ b/examples/src/main/scala/skuber/examples/auth/AwsAuthExample.scala
@@ -36,7 +36,7 @@ object AwsAuthExample extends App {
   listPods(namespace, 5)
   listPods(namespace, 11)
 
-  k8s.close
+  k8s.close()
   Await.result(as.terminate(), 10.seconds)
   System.exit(0)
 

--- a/examples/src/main/scala/skuber/examples/auth/InClusterConfigurationExample.scala
+++ b/examples/src/main/scala/skuber/examples/auth/InClusterConfigurationExample.scala
@@ -25,7 +25,7 @@ object InClusterConfigurationExample extends App {
       getApiVersions(5)
       getApiVersions(11)
 
-      k8s.close
+      k8s.close()
       Await.result(as.terminate(), 10.seconds)
       System.exit(0)
 

--- a/examples/src/main/scala/skuber/examples/customresources/v1/CreateCRD.scala
+++ b/examples/src/main/scala/skuber/examples/customresources/v1/CreateCRD.scala
@@ -99,13 +99,13 @@ object CreateCRD extends App {
   saveCRDs.onComplete{
     case Success(_) =>
       System.out.println("done!")
-      k8s.close
+      k8s.close()
       system.terminate().foreach { f =>
         System.exit(0)
       }
     case Failure(ex) =>
       System.err.println("Failed: " + ex)
-      k8s.close
+      k8s.close()
       system.terminate().foreach { f =>
         System.exit(1)
       }

--- a/examples/src/main/scala/skuber/examples/customresources/v1beta1/CreateCRD.scala
+++ b/examples/src/main/scala/skuber/examples/customresources/v1beta1/CreateCRD.scala
@@ -40,13 +40,13 @@ object CreateCRD extends App {
   saveCRDs onComplete {
     case Success(_) =>
       System.out.println("done!")
-      k8s.close
+      k8s.close()
       system.terminate().foreach { f =>
         System.exit(0)
       }
     case Failure(ex) =>
       System.err.println("Failed: " + ex)
-      k8s.close
+      k8s.close()
       system.terminate().foreach { f =>
         System.exit(1)
       }

--- a/examples/src/main/scala/skuber/examples/exec/ExecExamples.scala
+++ b/examples/src/main/scala/skuber/examples/exec/ExecExamples.scala
@@ -73,7 +73,7 @@ object ExecExamples extends App {
   fut.onComplete { _ =>
     println("\nFinishing up")
     k8s.delete[Pod]("sleep")
-    k8s.close
+    k8s.close()
     system.terminate().foreach { f =>
       System.exit(0)
     }

--- a/examples/src/main/scala/skuber/examples/fluent/FluentExamples.scala
+++ b/examples/src/main/scala/skuber/examples/fluent/FluentExamples.scala
@@ -311,7 +311,7 @@ object FluentExamples extends App {
     deployAll.failed.foreach {  case ex: K8SException => System.err.println("Request failed with status : " + ex.status) }
     
     deployAll andThen { case _ =>
-      k8s.close
+      k8s.close()
       system.terminate().foreach { f =>
         System.exit(0)
       }

--- a/examples/src/main/scala/skuber/examples/guestbook/KubernetesProxyActor.scala
+++ b/examples/src/main/scala/skuber/examples/guestbook/KubernetesProxyActor.scala
@@ -121,7 +121,7 @@ class KubernetesProxyActor extends Actor with ActorLogging {
     }
     
     case Close => {
-      k8s.close
+      k8s.close()
       System.out.println("Closed skuber client")
       system.terminate().foreach { f =>
         System.exit(0)

--- a/examples/src/main/scala/skuber/examples/job/PrintPiJob.scala
+++ b/examples/src/main/scala/skuber/examples/job/PrintPiJob.scala
@@ -31,13 +31,13 @@ object PrintPiJob extends App {
   jobCreateFut onComplete {
     case Success(job) =>
       System.out.println("Job successfully created on the cluster")
-      k8s.close
+      k8s.close()
       system.terminate().foreach { f =>
         System.exit(0)
       }
     case Failure(ex) =>
       System.err.println("Failed to create job: " + ex)
-      k8s.close
+      k8s.close()
       system.terminate().foreach { f =>
         System.exit(1)
       }

--- a/examples/src/main/scala/skuber/examples/list/ListExamples.scala
+++ b/examples/src/main/scala/skuber/examples/list/ListExamples.scala
@@ -67,7 +67,7 @@ object ListExamples extends App {
 
   Await.ready(printAllPods, 30.seconds)
 
-  k8s.close
+  k8s.close()
   system.terminate().foreach { f =>
     System.exit(0)
   }

--- a/examples/src/main/scala/skuber/examples/patch/PatchExamples.scala
+++ b/examples/src/main/scala/skuber/examples/patch/PatchExamples.scala
@@ -93,7 +93,7 @@ object PatchExamples extends App {
 
     Await.ready(cleanupRequested, Inf)
     println("Finishing up")
-    k8s.close
+    k8s.close()
     system.terminate()
   }
   scaleNginx

--- a/examples/src/main/scala/skuber/examples/podlogs/PodLogsExample.scala
+++ b/examples/src/main/scala/skuber/examples/podlogs/PodLogsExample.scala
@@ -49,7 +49,7 @@ object PodLogExample extends App {
   // allow another 5 seconds for logs to be streamed from the pod to stdout before cleaning up
   Thread.sleep(5000)
   Await.result(k8s.delete[Pod]("hello-world"), 5.seconds)
-  k8s.close
+  k8s.close()
   system.terminate()
   System.exit(0)
 }

--- a/examples/src/main/scala/skuber/examples/scale/ScaleExamples.scala
+++ b/examples/src/main/scala/skuber/examples/scale/ScaleExamples.scala
@@ -152,7 +152,7 @@ object ScaleExamples extends App {
 
     Await.ready(autoscaleDone, Inf)
     println("Finishing up")
-    k8s.close
+    k8s.close()
     system.terminate()
   }
   scaleNginx

--- a/examples/src/main/scala/skuber/examples/watch/WatchExamples.scala
+++ b/examples/src/main/scala/skuber/examples/watch/WatchExamples.scala
@@ -50,7 +50,7 @@ object WatchExamples extends App {
   watchFrontEndScaling
 
   Thread.sleep(1200000) // watch for a lengthy time before closing the session
-  k8s.close
+  k8s.close()
   system.terminate().foreach { f =>
     System.exit(0)
   }


### PR DESCRIPTION
It's a side-effecting method returning Unit.
Scala was emitting a warning for not having parenthesis as a suffix of the method name.